### PR TITLE
[FEAT] Add filesystem tracing with FileTracer and update CLI arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Ignore logs directory
-tracer/logs/
+logs/
 dist/
 tracer.egg-info/
 __pycache__/
+build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "rich",     # For rich logs and CLI formatting
+  "rich",             # For rich logs and CLI formatting
+  "inotify_simple",   # For filesystem tracing
 ]
 
 [project.scripts]

--- a/src/tracer/cli.py
+++ b/src/tracer/cli.py
@@ -3,13 +3,17 @@ from tracer.store.log_reader import LogReader
 from tracer.store.log_writer import LogWriter
 from tracer.config import LogDomain
 from tracer.core.base_tracer import BaseTracer
+from tracer.core.fs_tracer import FileTracer
 
-def start_tracing(domain: str):
+def start_tracing(domain: str, dir_to_watch: str = None):
     """Starts tracing for the specified domain."""
     if domain == "fs":
+        if not dir_to_watch:
+            print("Error: --dir is required for the 'fs' domain.")
+            return
         print("Starting filesystem tracing...")
         # Replace with actual FileTracer implementation
-        tracer = BaseTracer(LogWriter(LogDomain.FS))
+        tracer = FileTracer(LogWriter(LogDomain.FS), dir_to_watch)
         tracer.start()
     elif domain == "net":
         print("Starting network tracing...")
@@ -38,31 +42,37 @@ def main():
     start_parser.add_argument(
     "domain", 
     choices=[d.value for d in LogDomain], 
-    help="Domain to print logs for")
-
+    help="Domain to print logs for"
+    )
+    start_parser.add_argument(
+    "-d", "--dir", 
+    metavar="DIR", 
+    required=False, 
+    help="Directory to watch (required for 'fs' domain)"
+    )
     # Subcommand: logs
     logs_parser = subparsers.add_parser("logs", help="Print logs")
     logs_parser.add_argument(
         "domain", 
         choices=[d.value for d in LogDomain], 
-        help="Domain to print logs for")
-    
+        help="Domain to print logs for"
+    )
     logs_parser.add_argument(
         "-s", "--start",
         metavar="START", default=None,
         help="Start time for filtering logs "
-        "(ISO format or fuzzy: now, yesterday, or [number][s/m/h/d]).")
-    
+        "(ISO format or fuzzy: now, yesterday, or [number][s/m/h/d])."
+    )
     logs_parser.add_argument(
         "-e", "--end",
         metavar="END", default=None,
         help="End time for filtering logs "
-        "(ISO format or fuzzy: now, yesterday, or [number][s/m/h/d]).")
-
+        "(ISO format or fuzzy: now, yesterday, or [number][s/m/h/d])."
+    )
     args = parser.parse_args()
 
     if args.command == "start":
-        start_tracing(args.domain)
+        start_tracing(args.domain, args.dir)
     elif args.command == "logs":
         print_logs(args.domain, args.start, args.end)
 

--- a/src/tracer/core/fs_tracer.py
+++ b/src/tracer/core/fs_tracer.py
@@ -1,0 +1,117 @@
+from tracer.core.base_tracer import BaseTracer
+from tracer.store.log_writer import LogWriter
+import os
+from inotify_simple import INotify, flags
+
+class FileTracer(BaseTracer):
+    def __init__(self, writer: LogWriter, dir_to_watch: str):
+        """
+        Initialize the FileTracer.
+
+        Args:
+            writer (LogWriter): The log writer instance for appending events.
+            dir_to_watch (str): The directory to monitor.
+        """
+        super().__init__(writer)
+        self.dir_to_watch = dir_to_watch
+        self.log_file = self.writer.file_path
+        self.inotify = INotify()
+        self.watch_descriptors = {}
+
+    def add_watch_recursive(self, path: str, watch_flags: int):
+        """
+        Add inotify watches to a directory and its subdirectories.
+
+        Args:
+            path (str): The root directory to watch.
+            watch_flags (int): The inotify flags to monitor.
+
+        Returns:
+            dict: A mapping of watch descriptors to directory paths.
+        """
+        watch_descriptors = {}
+        log_file_parent = os.path.dirname(os.path.abspath(self.log_file))
+        
+        for root, dirs, files in os.walk(path):
+            if os.path.abspath(root) == log_file_parent:
+                continue
+            try:
+                wd = self.inotify.add_watch(root, watch_flags)
+                watch_descriptors[wd] = root
+                print(f"Added watch to: {root}")
+            except Exception as e:
+                print(f"Failed to add watch to {root}: {e}")
+        return watch_descriptors
+    
+    def handle_event(self, event, watch_flags):
+        """
+        Handle a single inotify event.
+
+        Args:
+            event: The inotify event.
+            watch_flags: The flags being monitored.
+        """
+        path = self.watch_descriptors.get(event.wd, "Unknown")
+        event_flags = flags.from_mask(event.mask)
+        event_name = event.name if event.name else "<root>"
+        full_path = os.path.join(path, event_name)
+
+        # Skip events on the log file
+        if os.path.abspath(full_path) == self.log_file:
+            return
+
+        event_details = {
+            "event_flags": [str(flag) for flag in event_flags],
+            "path": path,
+            "name": event_name,
+            "full_path": full_path,
+        }
+
+        print(event_details)
+        self.writer.append(event_details)
+
+        # Handle new subdirectory creation
+        if flags.CREATE in event_flags and os.path.isdir(full_path):
+            try:
+                new_wd = self.inotify.add_watch(full_path, watch_flags)
+                self.watch_descriptors[new_wd] = full_path
+                print(f"Added watch for new directory: {full_path}")
+            except Exception as e:
+                print(f"Failed to add watch for new directory {full_path}: {e}")
+
+
+    def start(self):
+        """
+        Start monitoring the directory and its subdirectories.
+        """
+        if not self.dir_to_watch:
+            raise ValueError("No directory specified to watch.")
+
+        # Define the flags to watch for
+        watch_flags = flags.CREATE | flags.DELETE | flags.MODIFY | flags.ATTRIB | flags.CLOSE_WRITE
+
+        # Add recursive watches
+        self.watch_descriptors = self.add_watch_recursive(self.dir_to_watch, watch_flags)
+        print(f"Started monitoring: {self.dir_to_watch} (and subdirectories)")
+
+        try:
+            while True:
+                for event in self.inotify.read():
+                    self.handle_event(event, watch_flags)
+        except KeyboardInterrupt:
+            print("Stopping monitoring...")
+        except Exception as e:
+            print(f"An error occurred: {e}")
+        finally:
+            self.cleanup()
+
+    def cleanup(self):
+        """
+        Clean up resources and remove all watches.
+        """
+        for wd in list(self.watch_descriptors.keys()):
+            try:
+                self.inotify.rm_watch(wd)
+            except Exception as e:
+                print(f"Failed to remove watch for {self.watch_descriptors[wd]}: {e}")
+        print("Cleaned up all watches.")


### PR DESCRIPTION
[FEAT] Add filesystem tracing with FileTracer and update CLI arguments

- Add recursive directory monitoring to FileTracer with inotify support
- Added `cleanup` method to remove all inotify watches and release resources on exit.
- Added --dir argument to start command (required for fs domain, optional otherwise) with validation.
